### PR TITLE
Add IPHONEOS_DEPLOYMENT_TARGET & Update README.md

### DIFF
--- a/Concurrency.xcodeproj/project.pbxproj
+++ b/Concurrency.xcodeproj/project.pbxproj
@@ -112,7 +112,7 @@
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -120,7 +120,6 @@
 				OBJ_13 /* Tests */,
 				OBJ_19 /* Products */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_7 /* Sources */ = {
@@ -208,7 +207,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_19 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -324,6 +323,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_NS_ASSERTIONS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "-DXcode";
@@ -363,6 +363,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_OPTIMIZATION_LEVEL = s;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_SWIFT_FLAGS = "-DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ brew install carthage
 To integrate Swift-Concurrency into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "https://github.com/uber/swift-concurrency.git" ~> 0.3.0
+github "https://github.com/uber/swift-concurrency.git" ~> 0.4.0
 ```
 
 Run `carthage update` to build the framework and add the built `Concurrency.framework` into your Xcode project, by following the [instructions](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ brew install carthage
 To integrate Swift-Concurrency into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "https://github.com/uber/swift-concurrency.git" ~> 0.2.0
+github "https://github.com/uber/swift-concurrency.git" ~> 0.3.0
 ```
 
 Run `carthage update` to build the framework and add the built `Concurrency.framework` into your Xcode project, by following the [instructions](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application)


### PR DESCRIPTION
When using `0.2.0` release with `Carthage` the user will receive an error, this diff updates the version to reflect the latest release.

```
*** Skipped building swift-concurrency due to the error:
Dependency "swift-concurrency" has no shared framework schemes for any of the platforms: iOS
```

Tested with `0.3.0` and works correctly with `Carthage`

Added `IPHONEOS_DEPLOYMENT_TARGET` and set it to `8.0.0` (this version should be fine right?)

