### PR TITLE
add an option to limit max concurrency

### DIFF
--- a/Sources/Concurrency/Executor/ConcurrentSequenceExecutor.swift
+++ b/Sources/Concurrency/Executor/ConcurrentSequenceExecutor.swift
@@ -34,12 +34,10 @@ public class ConcurrentSequenceExecutor: SequenceExecutor {
     /// when the timeout occurred. The tracking does incur a minor
     /// performance cost. This value defaults to `false`.
     /// - parameter maxConcurrentTasks: limits the maximum number of tasks
-    /// run concurrently. Defaults to 0, which will set the max to the number
-    /// of processors.
-    public init(name: String, qos: DispatchQoS = .userInitiated, shouldTrackTaskId: Bool = false, maxConcurrentTasks: Int = 0) {
+    /// run concurrently. Defaults to Int.max.
+    public init(name: String, qos: DispatchQoS = .userInitiated, shouldTrackTaskId: Bool = false, maxConcurrentTasks: Int = Int.max) {
         taskQueue = DispatchQueue(label: "Executor.taskQueue-\(name)", qos: qos, attributes: .concurrent)
-        let semaphoreCount = maxConcurrentTasks == 0 ? ProcessInfo().processorCount : maxConcurrentTasks
-        taskSemaphore = DispatchSemaphore(value: semaphoreCount)
+        taskSemaphore = DispatchSemaphore(value: maxConcurrentTasks)
         self.shouldTrackTaskId = shouldTrackTaskId
     }
 

--- a/Sources/Concurrency/Executor/ConcurrentSequenceExecutor.swift
+++ b/Sources/Concurrency/Executor/ConcurrentSequenceExecutor.swift
@@ -33,8 +33,13 @@ public class ConcurrentSequenceExecutor: SequenceExecutor {
     /// reported error contains the ID of the task that was being executed
     /// when the timeout occurred. The tracking does incur a minor
     /// performance cost. This value defaults to `false`.
-    public init(name: String, qos: DispatchQoS = .userInitiated, shouldTrackTaskId: Bool = false) {
+    /// - parameter maxConcurrentTasks: limits the maximum number of tasks
+    /// run concurrently. Defaults to 0, which will set the max to the number
+    /// of processors.
+    public init(name: String, qos: DispatchQoS = .userInitiated, shouldTrackTaskId: Bool = false, maxConcurrentTasks: Int = 0) {
         taskQueue = DispatchQueue(label: "Executor.taskQueue-\(name)", qos: qos, attributes: .concurrent)
+        let semaphoreCount = maxConcurrentTasks == 0 ? ProcessInfo().processorCount : maxConcurrentTasks
+        taskSemaphore = DispatchSemaphore(value: semaphoreCount)
         self.shouldTrackTaskId = shouldTrackTaskId
     }
 
@@ -58,10 +63,16 @@ public class ConcurrentSequenceExecutor: SequenceExecutor {
     // MARK: - Private
 
     private let taskQueue: DispatchQueue
+    private let taskSemaphore: DispatchSemaphore
     private let shouldTrackTaskId: Bool
 
     private func execute<SequenceResultType>(_ task: Task, with sequenceHandle: SynchronizedSequenceExecutionHandle<SequenceResultType>, _ execution: @escaping (Task, Any) -> SequenceExecution<SequenceResultType>) {
+        taskSemaphore.wait()
         taskQueue.async {
+            defer {
+                self.taskSemaphore.signal()
+            }
+            
             guard !sequenceHandle.isCancelled else {
                 return
             }


### PR DESCRIPTION
Add a param to limit the max number of concurrent tasks executed. It defaults to the number of processors on the machine.