### PR TITLE
Move defer outside of if statement

### DIFF
--- a/Sources/Concurrency/Executor/ConcurrentSequenceExecutor.swift
+++ b/Sources/Concurrency/Executor/ConcurrentSequenceExecutor.swift
@@ -72,10 +72,8 @@ public class ConcurrentSequenceExecutor: SequenceExecutor {
     private func execute<SequenceResultType>(_ task: Task, with sequenceHandle: SynchronizedSequenceExecutionHandle<SequenceResultType>, _ execution: @escaping (Task, Any) -> SequenceExecution<SequenceResultType>) {
         taskSemaphore?.wait()
         taskQueue.async {
-            if let taskSemaphore = self.taskSemaphore {
-                defer {
-                    taskSemaphore.signal()
-                }
+            defer {
+                self.taskSemaphore?.signal()
             }
 
             guard !sequenceHandle.isCancelled else {


### PR DESCRIPTION
Previously this defer would fire at the end of the if statement when it
likely should have been firing at the end of the dispatch_async.