### PR TITLE
Fixing Data Race Conditions caught by TSAN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ env:
   - ACTION=test  PLATFORM=tvOS    DESTINATION='platform=tvOS Simulator,name=Apple TV 4K'
 
 script:
-  - swift test
+  - swift test -c debug --sanitize=thread

--- a/Sources/Concurrency/AtomicInt.swift
+++ b/Sources/Concurrency/AtomicInt.swift
@@ -27,8 +27,6 @@ public class AtomicInt {
     /// The current value.
     public var value: Int {
         get {
-            // Create a memory barrier to ensure the entire memory stack is in sync so we
-            // can safely retrieve the value. This guarantees the initial value is in sync.
             return AtomicBridges.atomicLoad(wrappedValueOpaquePointer)
         }
         set {

--- a/Sources/ObjCBridges/AtomicBridges.m
+++ b/Sources/ObjCBridges/AtomicBridges.m
@@ -30,6 +30,10 @@
     return atomic_compare_exchange_strong(value, expected, desired);
 }
 
++ (long) atomicLoad:(_Atomic(long) *)value {
+    return atomic_load(value);
+}
+
 + (bool)comparePointer:(void * volatile *)value withExpectedPointer:(void *)expected andSwapPointer:(void *)desired {
     return __sync_bool_compare_and_swap(value, expected, desired);
 }

--- a/Sources/ObjCBridges/include/AtomicBridges.h
+++ b/Sources/ObjCBridges/include/AtomicBridges.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (bool)compare:(_Atomic(long) *)value withExpected:(long *)expected andSwap:(long)desired;
 
++ (long)atomicLoad:(_Atomic(long) *)value;
+
 + (bool)comparePointer:(void * _Nullable volatile * _Nonnull)value withExpectedPointer:(void *)expected andSwapPointer:(void *)desired;
 
 @end

--- a/Tests/ConcurrencyTests/AutoReleasingSemaphoreTests.swift
+++ b/Tests/ConcurrencyTests/AutoReleasingSemaphoreTests.swift
@@ -64,6 +64,7 @@ class AutoReleasingSemaphoreTests: XCTestCase {
         Thread.sleep(forTimeInterval: 1)
 
         waitForExpectations(timeout: 5, handler: nil)
+        
         semaphore = nil
 
     }

--- a/Tests/ConcurrencyTests/AutoReleasingSemaphoreTests.swift
+++ b/Tests/ConcurrencyTests/AutoReleasingSemaphoreTests.swift
@@ -29,9 +29,11 @@ class AutoReleasingSemaphoreTests: XCTestCase {
         }
 
         Thread.sleep(forTimeInterval: 1)
-        semaphore = nil
 
         waitForExpectations(timeout: 5, handler: nil)
+      
+        semaphore = nil
+
     }
 
     func test_waitWithTimeout_verifyTimeout() {
@@ -60,8 +62,9 @@ class AutoReleasingSemaphoreTests: XCTestCase {
         }
 
         Thread.sleep(forTimeInterval: 1)
-        semaphore = nil
 
         waitForExpectations(timeout: 5, handler: nil)
+        semaphore = nil
+
     }
 }


### PR DESCRIPTION
Hey :))
Running the tests with Tsan Enabled, caught some data race conditions:
As we can note on the sreen shots bellow:

<img width="896" alt="Screen Shot 2019-08-24 at 18 02 26" src="https://user-images.githubusercontent.com/8292651/63642695-9beff100-c699-11e9-8a07-333dfe38c187.png">
<img width="899" alt="Screen Shot 2019-08-24 at 18 02 47" src="https://user-images.githubusercontent.com/8292651/63642696-9beff100-c699-11e9-9e41-6d68342f385f.png">

This PR fixes them and also enables it on the travis, it can check for issues on CI.
 