### PR TITLE
Update module map header & expose ObjCBridges for Carthage build

### DIFF
--- a/Concurrency.xcodeproj/GeneratedModuleMap/ObjCBridges/module.modulemap
+++ b/Concurrency.xcodeproj/GeneratedModuleMap/ObjCBridges/module.modulemap
@@ -1,4 +1,4 @@
 module ObjCBridges {
-    umbrella "/Users/yiw/Uber/GitHub/swift-concurrency/Sources/ObjCBridges/include"
+    umbrella "../../../Sources/ObjCBridges/include"
     export *
 }

--- a/Concurrency.xcodeproj/xcshareddata/xcschemes/Concurrency.xcscheme
+++ b/Concurrency.xcodeproj/xcshareddata/xcschemes/Concurrency.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Concurrency.xcodeproj/xcshareddata/xcschemes/ConcurrencyTests.xcscheme
+++ b/Concurrency.xcodeproj/xcshareddata/xcschemes/ConcurrencyTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Concurrency.xcodeproj/xcshareddata/xcschemes/ObjCBridges.xcscheme
+++ b/Concurrency.xcodeproj/xcshareddata/xcschemes/ObjCBridges.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1030"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Concurrency::ObjCBridges"
+               BuildableName = "ObjCBridges.framework"
+               BlueprintName = "ObjCBridges"
+               ReferencedContainer = "container:Concurrency.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Concurrency::ObjCBridges"
+            BuildableName = "ObjCBridges.framework"
+            BlueprintName = "ObjCBridges"
+            ReferencedContainer = "container:Concurrency.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Concurrency::ObjCBridges"
+            BuildableName = "ObjCBridges.framework"
+            BlueprintName = "ObjCBridges"
+            ReferencedContainer = "container:Concurrency.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Applications need to add ObjCBridges to their project, this diff adds a scheme for ObjCBridges so carthage will build the framework.
