### PR TITLE
Implicit Returns from Single-Expression Functions And Refactoring

### DIFF
--- a/Sources/Concurrency/AtomicBool.swift
+++ b/Sources/Concurrency/AtomicBool.swift
@@ -70,10 +70,10 @@ public class AtomicBool {
     private let backingAtomic: AtomicInt
 
     private static func boolToInt(value: Bool) -> Int {
-        return value ? AtomicBool.trueIntValue : AtomicBool.falseIntValue
+        value ? AtomicBool.trueIntValue : AtomicBool.falseIntValue
     }
 
     private static func intToBool(value: Int) -> Bool {
-        return (value == AtomicBool.trueIntValue) ? true : false
+        value == AtomicBool.trueIntValue
     }
 }

--- a/Sources/Concurrency/AtomicInt.swift
+++ b/Sources/Concurrency/AtomicInt.swift
@@ -93,7 +93,7 @@ public class AtomicInt {
     /// - returns: The old value before incrementing.
     @discardableResult
     public func getAndIncrement() -> Int {
-        return AtomicBridges.fetchAndIncrementBarrier(wrappedValueOpaquePointer)
+        AtomicBridges.fetchAndIncrementBarrier(wrappedValueOpaquePointer)
     }
 
     /// Atomically decrement the value and retrieve the old value.
@@ -101,7 +101,7 @@ public class AtomicInt {
     /// - returns: The old value before decrementing.
     @discardableResult
     public func getAndDecrement() -> Int {
-        return AtomicBridges.fetchAndDecrementBarrier(wrappedValueOpaquePointer)
+        AtomicBridges.fetchAndDecrementBarrier(wrappedValueOpaquePointer)
     }
 
     /// Atomically sets to the given new value and returns the old value.
@@ -123,6 +123,6 @@ public class AtomicInt {
     private var wrappedValue: Int
 
     private var wrappedValueOpaquePointer: OpaquePointer {
-        return OpaquePointer(UnsafeMutablePointer<Int>(&wrappedValue))
+        OpaquePointer(UnsafeMutablePointer<Int>(&wrappedValue))
     }
 }

--- a/Sources/Concurrency/AtomicReference.swift
+++ b/Sources/Concurrency/AtomicReference.swift
@@ -90,7 +90,7 @@ public class AtomicReference<ValueType> {
     private var wrappedValue: ValueType
 
     private func unsafePassUnretainedPointer(value: ValueType) -> UnsafeMutableRawPointer {
-        return UnsafeMutableRawPointer(Unmanaged.passUnretained(value as AnyObject).toOpaque())
+        UnsafeMutableRawPointer(Unmanaged.passUnretained(value as AnyObject).toOpaque())
     }
 
     deinit {


### PR DESCRIPTION
Proposal: [SE-0255](https://github.com/apple/swift-evolution/blob/main/proposals/0255-omit-return.md)
It states that we can omit single expression return and can use implicit return type.

Refactoring:
```
private static func intToBool(value: Int) -> Bool {
        return (value == AtomicBool.trueIntValue) ? true : false
}
```
Here statement
`value == AtomicBool.trueIntValue`
 itself states that if condition is true or false. So we can use its value to return  it rather than using explicitly true and false to return
 
 - [x] Run the test cases
 - [x] Attached reference of concept

